### PR TITLE
Add Stream Parser Variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "coverage": "nyc mocha",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
-    "lint": "tslint -t stylish --project \"tsconfig.json\"",
-    "lint:fix": "tslint -t stylish --fix --project \"tsconfig.json\"",
+    "lint": "tslint -t stylish --project \"tsconfig.lint.json\"",
+    "lint:fix": "tslint -t stylish --fix --project \"tsconfig.lint.json\"",
     "test": "mocha",
     "test:watch": "nodemon --watch src --watch test -e ts,js --exec \"clear; yarn run test\""
   }

--- a/src/classes/builders/detailedSummaryBuilder.ts
+++ b/src/classes/builders/detailedSummaryBuilder.ts
@@ -50,7 +50,7 @@ class DetailedSummaryBuilder extends SummaryBuilder {
       return;
     }
     super.parse(line);
-    const [type, ...contents] = line.split(':');
+    const [type, ...contents] = line.trim().split(':');
     const content = contents.join(':');
     try {
       switch (type) {

--- a/src/classes/builders/summaryBuilder.ts
+++ b/src/classes/builders/summaryBuilder.ts
@@ -47,7 +47,7 @@ class SummaryBuilder {
     if (!line.trim().length) {
       return;
     }
-    const [type, ...contents] = line.split(':');
+    const [type, ...contents] = line.trim().split(':');
     const content = contents.join(':');
     try {
       switch (type) {

--- a/src/classes/parsers/browserStreamParser.ts
+++ b/src/classes/parsers/browserStreamParser.ts
@@ -2,9 +2,9 @@ import { ReportMode } from '../../utils';
 
 import Report from '../reports/report';
 
-import Parser from './parser';
+import StreamParser from './streamParser';
 
-class BrowserStreamParser extends Parser {
+class BrowserStreamParser extends StreamParser {
   public async parse(
     stream: ReadableStream,
     options: {
@@ -28,17 +28,6 @@ class BrowserStreamParser extends Parser {
     };
     await handleLine();
     return builder.build();
-  }
-
-  public parseSync(
-    _: ReadableStream,
-    __: {
-      encoding?: string;
-      rootDirectory?: string;
-      mode?: ReportMode;
-    } = {},
-  ): Report {
-    throw new Error('Synchronous parsing with string is not supported!');
   }
 
   private createLineTransformer(

--- a/src/classes/parsers/browserStreamParser.ts
+++ b/src/classes/parsers/browserStreamParser.ts
@@ -4,7 +4,7 @@ import Report from '../reports/report';
 
 import Parser from './parser';
 
-class StreamParser extends Parser {
+class BrowserStreamParser extends Parser {
   public async parse(
     stream: ReadableStream,
     options: {
@@ -73,4 +73,4 @@ class StreamParser extends Parser {
   }
 }
 
-export default StreamParser;
+export default BrowserStreamParser;

--- a/src/classes/parsers/nodeStreamParser.ts
+++ b/src/classes/parsers/nodeStreamParser.ts
@@ -1,0 +1,45 @@
+import { Readable } from 'stream';
+
+import { ReportMode } from '../../utils';
+import LineTransformer from '../../utils/lineTransformer';
+
+import Report from '../reports/report';
+
+import StreamParser from './streamParser';
+
+class NodeStreamParser extends StreamParser {
+  public async parse(
+    stream: Readable,
+    options: {
+      encoding?: string;
+      rootDirectory?: string;
+      mode?: ReportMode;
+    } = {},
+  ): Promise<Report> {
+    const { encoding, rootDirectory, mode } = options;
+    const builder = this.createBuilder(rootDirectory, mode);
+    const transformed = new LineTransformer(encoding);
+    stream.pipe(transformed);
+
+    return new Promise((resolve, reject) => {
+      transformed.on('data', chunk => {
+        const line = chunk.toString();
+        builder.parse(line);
+      });
+
+      transformed.on('end', () => {
+        const report = builder.build();
+        transformed.removeAllListeners();
+        resolve(report);
+      });
+
+      transformed.on('error', err => {
+        reject(err);
+        transformed.removeAllListeners();
+        transformed.end();
+      });
+    });
+  }
+}
+
+export default NodeStreamParser;

--- a/src/classes/parsers/nodeStreamParser.ts
+++ b/src/classes/parsers/nodeStreamParser.ts
@@ -23,20 +23,32 @@ class NodeStreamParser extends StreamParser {
 
     return new Promise((resolve, reject) => {
       transformed.on('data', chunk => {
-        const line = chunk.toString();
-        builder.parse(line);
+        try {
+          const line = chunk.toString();
+          builder.parse(line);
+        } catch (err) {
+          transformed.removeAllListeners();
+          transformed.end();
+          reject(err);
+        }
       });
 
       transformed.on('end', () => {
-        const report = builder.build();
-        transformed.removeAllListeners();
-        resolve(report);
+        try {
+          const report = builder.build();
+          transformed.removeAllListeners();
+          resolve(report);
+        } catch (err) {
+          transformed.removeAllListeners();
+          transformed.end();
+          reject(err);
+        }
       });
 
       transformed.on('error', err => {
-        reject(err);
         transformed.removeAllListeners();
         transformed.end();
+        reject(err);
       });
     });
   }

--- a/src/classes/parsers/parser.ts
+++ b/src/classes/parsers/parser.ts
@@ -7,7 +7,7 @@ import Report from '../reports/report';
 
 abstract class Parser {
   public abstract async parse(
-    _: string | ReadableStream,
+    _: any,
     __: {
       encoding?: string;
       rootDirectory?: string;
@@ -16,7 +16,7 @@ abstract class Parser {
   ): Promise<Report>;
 
   public abstract parseSync(
-    _: string | ReadableStream,
+    _: any,
     __: { encoding?: string; rootDirectory?: string },
   ): Report;
 

--- a/src/classes/parsers/streamParser.ts
+++ b/src/classes/parsers/streamParser.ts
@@ -1,0 +1,20 @@
+import { ReportMode } from '../../utils';
+
+import Report from '../reports/report';
+
+import Parser from './parser';
+
+abstract class StreamParser extends Parser {
+  public parseSync(
+    _: any,
+    __: {
+      encoding?: string;
+      rootDirectory?: string;
+      mode?: ReportMode;
+    } = {},
+  ): Report {
+    throw new Error('Synchronous parsing with streams is not supported!');
+  }
+}
+
+export default StreamParser;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
+import BrowserStreamParser from './classes/parsers/browserStreamParser';
 import ContentParser from './classes/parsers/contentParser';
 import FileParser from './classes/parsers/fileParser';
-import StreamParser from './classes/parsers/streamParser';
 import { ReportMode } from './utils';
 
 export default {
+  BrowserStreamParser,
   ContentParser,
   FileParser,
   ReportMode,
-  StreamParser,
 };

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,13 +1,11 @@
-import BrowserStreamParser from './classes/parsers/browserStreamParser';
 import ContentParser from './classes/parsers/contentParser';
 import FileParser from './classes/parsers/fileParser';
-import NodeStreamParser from './classes/parsers/nodeStreamParser';
+import StreamParser from './classes/parsers/nodeStreamParser';
 import { ReportMode } from './utils';
 
 export default {
-  BrowserStreamParser,
   ContentParser,
   FileParser,
-  NodeStreamParser,
   ReportMode,
+  StreamParser,
 };

--- a/src/utils/lineTransformer.ts
+++ b/src/utils/lineTransformer.ts
@@ -11,13 +11,11 @@ class LineTransformer extends Transform {
 
   public _transform(
     chunk: any,
-    encoding: string,
+    _: string,
     callback: (error?: Error | null, data?: any) => void,
   ): void {
     try {
-      const encodeType =
-        (encoding === 'buffer' || !encoding) ? this._encoding : encoding;
-      const chunkStr: string = chunk.toString(encodeType);
+      const chunkStr: string = chunk.toString(this._encoding);
       const total = this._overflow + chunkStr;
       const lines = total.split('\n');
       this._overflow = lines.pop() || '';
@@ -31,14 +29,10 @@ class LineTransformer extends Transform {
   }
 
   public _flush(callback: (error?: Error | null, data?: any) => void): void {
-    try {
-      this._overflow.split('\n').forEach(line => {
-        this.push(Buffer.from(line));
-      });
-      callback(null, null);
-    } catch (err) {
-      callback(err, null);
-    }
+    this._overflow.split('\n').forEach(line => {
+      this.push(Buffer.from(line));
+    });
+    callback(null, null);
   }
 }
 

--- a/src/utils/lineTransformer.ts
+++ b/src/utils/lineTransformer.ts
@@ -1,0 +1,45 @@
+import { Transform } from 'stream';
+
+class LineTransformer extends Transform {
+  private _overflow: string = '';
+  private _encoding: string;
+
+  constructor(encoding: string = 'utf-8') {
+    super();
+    this._encoding = encoding;
+  }
+
+  public _transform(
+    chunk: any,
+    encoding: string,
+    callback: (error?: Error | null, data?: any) => void,
+  ): void {
+    try {
+      const encodeType =
+        (encoding === 'buffer' || !encoding) ? this._encoding : encoding;
+      const chunkStr: string = chunk.toString(encodeType);
+      const total = this._overflow + chunkStr;
+      const lines = total.split('\n');
+      this._overflow = lines.pop() || '';
+      lines.forEach(line => {
+        this.push(Buffer.from(line));
+      });
+      callback(null, null);
+    } catch (err) {
+      callback(err, null);
+    }
+  }
+
+  public _flush(callback: (error?: Error | null, data?: any) => void): void {
+    try {
+      this._overflow.split('\n').forEach(line => {
+        this.push(Buffer.from(line));
+      });
+      callback(null, null);
+    } catch (err) {
+      callback(err, null);
+    }
+  }
+}
+
+export default LineTransformer;

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,0 +1,9 @@
+import StreamParser from './classes/parsers/browserStreamParser';
+import ContentParser from './classes/parsers/contentParser';
+import { ReportMode } from './utils';
+
+export default {
+  ContentParser,
+  ReportMode,
+  StreamParser,
+};

--- a/test/classes/parsers/contentParser.test.ts
+++ b/test/classes/parsers/contentParser.test.ts
@@ -160,8 +160,8 @@ describe('ContentParser', () => {
 
       it('should parse contents into a Report when using Simple Report Mode', async () => {
         const report = await parser.parse(parserContents, {
-          rootDirectory: '/root',
           mode: ReportMode.Simple,
+          rootDirectory: '/root',
         });
         expect(report).to.be.an.instanceOf(Report);
         validateBasicReport(report);
@@ -169,8 +169,8 @@ describe('ContentParser', () => {
 
       it('should parse contents into a FlatReport when using Detail Report Mode', async () => {
         const report = await parser.parse(parserContents, {
-          rootDirectory: '/root',
           mode: ReportMode.Detail,
+          rootDirectory: '/root',
         });
         expect(report).to.be.an.instanceOf(FlatReport);
         validateDetailReport(report);
@@ -178,8 +178,8 @@ describe('ContentParser', () => {
 
       it('should parse contents into a TreeReport when using Tree Report Mode', async () => {
         const report = await parser.parse(parserContents, {
-          rootDirectory: '/root',
           mode: ReportMode.Tree,
+          rootDirectory: '/root',
         });
         expect(report).to.be.an.instanceOf(TreeReport);
         validateDetailReport(report);
@@ -253,8 +253,8 @@ describe('ContentParser', () => {
 
       it('should parse contents into a Report when using Simple Report Mode', () => {
         const report = parser.parseSync(parserContents, {
-          rootDirectory: '/root',
           mode: ReportMode.Simple,
+          rootDirectory: '/root',
         });
         expect(report).to.be.an.instanceOf(Report);
         validateBasicReport(report);
@@ -262,8 +262,8 @@ describe('ContentParser', () => {
 
       it('should parse contents into a FlatReport when using Detail Report Mode', () => {
         const report = parser.parseSync(parserContents, {
-          rootDirectory: '/root',
           mode: ReportMode.Detail,
+          rootDirectory: '/root',
         });
         expect(report).to.be.an.instanceOf(FlatReport);
         validateDetailReport(report);
@@ -271,8 +271,8 @@ describe('ContentParser', () => {
 
       it('should parse contents into a TreeReport when using Tree Report Mode', () => {
         const report = parser.parseSync(parserContents, {
-          rootDirectory: '/root',
           mode: ReportMode.Tree,
+          rootDirectory: '/root',
         });
         expect(report).to.be.an.instanceOf(TreeReport);
         validateDetailReport(report);

--- a/test/classes/parsers/fileParser.test.ts
+++ b/test/classes/parsers/fileParser.test.ts
@@ -20,6 +20,14 @@ describe('FileParser', () => {
   let sandbox: sinon.SinonSandbox;
   let parser: FileParser;
 
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   it('should construct properly when fs.readFile and fs.readFileSync are supported', () => {
     sandbox.stub(fs, 'readFile');
     sandbox.stub(fs, 'readFileSync');
@@ -53,14 +61,6 @@ describe('FileParser', () => {
     expect(() => {
       parser = new FileParser();
     }).to.throw('FileParser is not supported in this environment!');
-  });
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   describe('parse', () => {

--- a/test/classes/parsers/fileParser.test.ts
+++ b/test/classes/parsers/fileParser.test.ts
@@ -99,8 +99,8 @@ describe('FileParser', () => {
 
         it('should parse file into a Report using Simple Report Mode', async () => {
           const report = await parser.parse('testpath', {
-            rootDirectory: '/root',
             mode: ReportMode.Simple,
+            rootDirectory: '/root',
           });
           expect(report).to.be.an.instanceOf(Report);
           validateBasicReport(report);
@@ -109,8 +109,8 @@ describe('FileParser', () => {
 
         it('should parse file into a FlatReport using Detail Report Mode', async () => {
           const report = await parser.parse('testpath', {
-            rootDirectory: '/root',
             mode: ReportMode.Detail,
+            rootDirectory: '/root',
           });
           expect(report).to.be.an.instanceOf(FlatReport);
           validateDetailReport(report);
@@ -119,8 +119,8 @@ describe('FileParser', () => {
 
         it('should parse file into a TreeReport using Tree Report Mode', async () => {
           const report = await parser.parse('testpath', {
-            rootDirectory: '/root',
             mode: ReportMode.Tree,
+            rootDirectory: '/root',
           });
           expect(report).to.be.an.instanceOf(TreeReport);
           validateDetailReport(report);
@@ -324,8 +324,8 @@ describe('FileParser', () => {
 
         it('should parse file into a Report using Simple Report Mode', () => {
           const report = parser.parseSync('testpath', {
-            rootDirectory: '/root',
             mode: ReportMode.Simple,
+            rootDirectory: '/root',
           });
           expect(report).to.be.an.instanceOf(Report);
           validateBasicReport(report);
@@ -334,8 +334,8 @@ describe('FileParser', () => {
 
         it('should parse file into a FlatReport using Detail Report Mode', () => {
           const report = parser.parseSync('testpath', {
-            rootDirectory: '/root',
             mode: ReportMode.Detail,
+            rootDirectory: '/root',
           });
           expect(report).to.be.an.instanceOf(FlatReport);
           validateDetailReport(report);
@@ -344,8 +344,8 @@ describe('FileParser', () => {
 
         it('should parse file into a TreeReport using Tree Report Mode', () => {
           const report = parser.parseSync('testpath', {
-            rootDirectory: '/root',
             mode: ReportMode.Tree,
+            rootDirectory: '/root',
           });
           expect(report).to.be.an.instanceOf(TreeReport);
           validateDetailReport(report);

--- a/test/classes/parsers/nodeStreamParser.test.ts
+++ b/test/classes/parsers/nodeStreamParser.test.ts
@@ -1,0 +1,286 @@
+import chai, { assert, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import 'mocha';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { PassThrough } from 'stream';
+
+import NodeStreamParser from '../../../src/classes/parsers/nodeStreamParser';
+import FlatReport from '../../../src/classes/reports/flatReport';
+import Report from '../../../src/classes/reports/report';
+import TreeReport from '../../../src/classes/reports/treeReport';
+import { ReportMode } from '../../../src/utils';
+import LineTransformer from '../../../src/utils/lineTransformer';
+
+import { parserTesting } from './contentParser.test';
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe('NodeStreamParser', () => {
+  let sandbox: sinon.SinonSandbox;
+  let parser: NodeStreamParser;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should construct properly', () => {
+    parser = new NodeStreamParser();
+    expect(parser).to.be.an.instanceOf(NodeStreamParser);
+    assert.isDefined(parser.parse);
+    assert.isDefined(parser.parseSync);
+  });
+
+  describe('parse', () => {
+    let passThrough: PassThrough;
+    let originalCreateBuilder: (...args: any[]) => any;
+    let parserCreateBuilderStub: sinon.SinonStub;
+    let builderParseSpy: sinon.SinonSpy;
+    let builderBuildSpy: sinon.SinonSpy;
+
+    beforeEach(() => {
+      passThrough = new PassThrough();
+      parser = new NodeStreamParser();
+      // Disable lint since we can only access protected method "createBuilder" this way
+      // tslint:disable-next-line:no-string-literal
+      originalCreateBuilder = parser['createBuilder'];
+      // Using ""'createBuilder' as any" allows us to stub the protected method
+      // NOTE: this is potentially subject to breakages if we move away from 'createBuilder'
+      // in future versions of the Parser interface.
+      parserCreateBuilderStub = sandbox
+        .stub(parser, 'createBuilder' as any)
+        .callsFake((rootDirectory, mode) => {
+          const builder = originalCreateBuilder(
+            rootDirectory as string,
+            mode as ReportMode,
+          );
+          builderParseSpy = sandbox.spy(builder, 'parse');
+          builderBuildSpy = sandbox.spy(builder, 'build');
+          return builder;
+        });
+    });
+
+    describe('when passing root directory', () => {
+      const validateBasicReport = (report: Report) => {
+        parserTesting.validateTotalSummary(report);
+        parserTesting.validatePath(report, 'test');
+        parserTesting.validateBasicSummary(report, 'test');
+      };
+
+      const validateDetailReport = (report: Report) => {
+        validateBasicReport(report);
+        parserTesting.validateDetailSummary(report as FlatReport, 'test');
+      };
+
+      it('should parse stream into a Report by default', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          rootDirectory: '/root',
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(Report);
+        validateBasicReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith('/root', undefined);
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+
+      it('should parse stream into a Report when using Simple Report Mode', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          mode: ReportMode.Simple,
+          rootDirectory: '/root',
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(Report);
+        validateBasicReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith('/root', ReportMode.Simple);
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+
+      it('should parse stream into a FlatReport when using Detail Report Mode', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          mode: ReportMode.Detail,
+          rootDirectory: '/root',
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(FlatReport);
+        validateDetailReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith('/root', ReportMode.Detail);
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+
+      it('should parse stream into a TreeReport when using Tree Report Mode', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          mode: ReportMode.Tree,
+          rootDirectory: '/root',
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(TreeReport);
+        validateDetailReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith('/root', ReportMode.Tree);
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+    });
+
+    describe('when not passing root directory', () => {
+      const validateBasicReport = (report: Report) => {
+        parserTesting.validateTotalSummary(report);
+        parserTesting.validatePath(report, '/root/test');
+        parserTesting.validateBasicSummary(report, '/root/test');
+      };
+
+      const validateDetailReport = (report: Report) => {
+        validateBasicReport(report);
+        parserTesting.validateDetailSummary(report as FlatReport, '/root/test');
+      };
+
+      it('should parse stream into a Report by default', async () => {
+        const parsePromise = parser.parse(passThrough);
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(Report);
+        validateBasicReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith(undefined, undefined);
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+
+      it('should parse stream into a Report when using Simple Report Mode', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          mode: ReportMode.Simple,
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(Report);
+        validateBasicReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith(
+          undefined,
+          ReportMode.Simple,
+        );
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+
+      it('should parse stream into a FlatReport when using Detail Report Mode', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          mode: ReportMode.Detail,
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(FlatReport);
+        validateDetailReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith(
+          undefined,
+          ReportMode.Detail,
+        );
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+
+      it('should parse stream into a TreeReport when using Tree Report Mode', async () => {
+        const parsePromise = parser.parse(passThrough, {
+          mode: ReportMode.Tree,
+        });
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        const report = await parsePromise;
+        expect(report).to.be.an.instanceOf(TreeReport);
+        validateDetailReport(report);
+        expect(parserCreateBuilderStub.callCount).to.equal(1);
+        expect(parserCreateBuilderStub).calledWith(undefined, ReportMode.Tree);
+        expect(builderParseSpy.callCount).to.equal(25);
+        assert.isTrue(builderBuildSpy.calledOnce);
+      });
+    });
+
+    describe('when streaming fails', () => {
+      let builderParseStub: sinon.SinonStub;
+      let builderBuildStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        parserCreateBuilderStub.callsFake((rootDirectory, mode) => {
+          const builder = originalCreateBuilder(
+            rootDirectory as string,
+            mode as ReportMode,
+          );
+          builderParseStub = sandbox.stub(builder, 'parse');
+          builderBuildStub = sandbox.stub(builder, 'build');
+          return builder;
+        });
+      });
+
+      it('should reject when parsing fails', async () => {
+        parserCreateBuilderStub.callsFake((rootDirectory, mode) => {
+          const builder = originalCreateBuilder(
+            rootDirectory as string,
+            mode as ReportMode,
+          );
+          builderParseStub = sandbox
+            .stub(builder, 'parse')
+            .throws(new Error('parse error'));
+          return builder;
+        });
+        const parsePromise = parser.parse(passThrough);
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        await expect(parsePromise).eventually.to.be.rejectedWith('parse error');
+        assert.isTrue(builderParseStub.called);
+      });
+
+      it('should reject when building fails', async () => {
+        parserCreateBuilderStub.callsFake((rootDirectory, mode) => {
+          const builder = originalCreateBuilder(
+            rootDirectory as string,
+            mode as ReportMode,
+          );
+          builderBuildStub = sandbox
+            .stub(builder, 'build')
+            .throws(new Error('build error'));
+          return builder;
+        });
+        const parsePromise = parser.parse(passThrough);
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        await expect(parsePromise).eventually.to.be.rejectedWith('build error');
+        assert.isTrue(builderBuildStub.called);
+      });
+
+      it('should reject when stream errors out', async () => {
+        const lineTransformerStub = sandbox
+          .stub(LineTransformer.prototype, 'push')
+          .throws(new Error('transform error'));
+        const parsePromise = parser.parse(passThrough);
+        passThrough.write(parserTesting.parserContents);
+        passThrough.end();
+        await expect(parsePromise).eventually.to.be.rejectedWith(
+          'transform error',
+        );
+        assert.isTrue(lineTransformerStub.called);
+      });
+    });
+  });
+});

--- a/test/classes/parsers/streamParser.test.ts
+++ b/test/classes/parsers/streamParser.test.ts
@@ -28,8 +28,8 @@ describe('StreamParser (Abstract)', () => {
     expect(() => {
       sp.parseSync('something', {
         encoding: 'buffer',
-        rootDirectory: '/root',
         mode: ReportMode.Simple,
+        rootDirectory: '/root',
       });
     }).to.throw(/not supported/);
   });

--- a/test/classes/parsers/streamParser.test.ts
+++ b/test/classes/parsers/streamParser.test.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import StreamParser from '../../../src/classes/parsers/streamParser';
+import Report from '../../../src/classes/reports/report';
+import { ReportMode } from '../../../src/utils';
+
+class StreamParserTest extends StreamParser {
+  public async parse(
+    _: any,
+    __: {
+      encoding?: string;
+      rootDirectory?: string;
+      mode?: ReportMode;
+    } = {},
+  ): Promise<Report> {
+    throw new Error('This is not implemented!');
+  }
+}
+
+describe('StreamParser (Abstract)', () => {
+  it('should throw an error for parseSync', () => {
+    const sp: StreamParser = new StreamParserTest();
+    expect(sp).to.be.an.instanceOf(StreamParser);
+    expect(() => {
+      sp.parseSync('something');
+    }).to.throw(/not supported/);
+    expect(() => {
+      sp.parseSync('something', {
+        encoding: 'buffer',
+        rootDirectory: '/root',
+        mode: ReportMode.Simple,
+      });
+    }).to.throw(/not supported/);
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,12 @@ it('top level export should expose correct elements', () => {
   assert.isDefined(topLevel.ContentParser, 'Content Parser should be exposed');
   assert.isDefined(topLevel.FileParser, 'File Parser should be exposed');
   assert.isDefined(topLevel.ReportMode, 'Report Mode should be exposed');
-  assert.isDefined(topLevel.NodeStreamParser, 'Node Stream Parser should be exposed');
-  assert.isDefined(topLevel.BrowserStreamParser, 'Browser Stream Parser should be exposed');
+  assert.isDefined(
+    topLevel.NodeStreamParser,
+    'Node Stream Parser should be exposed',
+  );
+  assert.isDefined(
+    topLevel.BrowserStreamParser,
+    'Browser Stream Parser should be exposed',
+  );
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,5 +7,6 @@ it('top level export should expose correct elements', () => {
   assert.isDefined(topLevel.ContentParser, 'Content Parser should be exposed');
   assert.isDefined(topLevel.FileParser, 'File Parser should be exposed');
   assert.isDefined(topLevel.ReportMode, 'Report Mode should be exposed');
-  assert.isDefined(topLevel.StreamParser, 'Stream Parser should be exposed');
+  assert.isDefined(topLevel.NodeStreamParser, 'Node Stream Parser should be exposed');
+  assert.isDefined(topLevel.BrowserStreamParser, 'Browser Stream Parser should be exposed');
 });

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -1,0 +1,11 @@
+import { assert } from 'chai';
+import 'mocha';
+
+import topLevelNode from '../src/node';
+
+it('top level node export should expose correct elements', () => {
+  assert.isDefined(topLevelNode.ContentParser, 'Content Parser should be exposed');
+  assert.isDefined(topLevelNode.FileParser, 'File Parser should be exposed');
+  assert.isDefined(topLevelNode.ReportMode, 'Report Mode should be exposed');
+  assert.isDefined(topLevelNode.StreamParser, 'Stream Parser should be exposed');
+});

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -4,8 +4,14 @@ import 'mocha';
 import topLevelNode from '../src/node';
 
 it('top level node export should expose correct elements', () => {
-  assert.isDefined(topLevelNode.ContentParser, 'Content Parser should be exposed');
+  assert.isDefined(
+    topLevelNode.ContentParser,
+    'Content Parser should be exposed',
+  );
   assert.isDefined(topLevelNode.FileParser, 'File Parser should be exposed');
   assert.isDefined(topLevelNode.ReportMode, 'Report Mode should be exposed');
-  assert.isDefined(topLevelNode.StreamParser, 'Stream Parser should be exposed');
+  assert.isDefined(
+    topLevelNode.StreamParser,
+    'Stream Parser should be exposed',
+  );
 });

--- a/test/utils/lineTransformer.test.ts
+++ b/test/utils/lineTransformer.test.ts
@@ -1,0 +1,143 @@
+import chai, { assert, expect } from 'chai';
+import 'mocha';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { PassThrough, Transform } from 'stream';
+
+import LineTransformer from '../../src/utils/lineTransformer';
+
+chai.use(sinonChai);
+
+describe('LineTransformer', () => {
+  it('should contruct properly', () => {
+    const lt = new LineTransformer();
+    expect(lt).to.be.an.instanceOf(Transform);
+    expect(lt).to.be.an.instanceOf(LineTransformer);
+  });
+
+  it('should transform stream into lines', async () => {
+    const stub = sinon.stub();
+    const passThrough = new PassThrough();
+    const lt = new LineTransformer();
+    passThrough.pipe(lt);
+    lt.on('data', chunk => {
+      stub(chunk.toString());
+    });
+    const endPromise = new Promise(resolve => {
+      lt.on('end', resolve);
+    });
+
+    passThrough.write(Buffer.from('testing', 'utf-8'));
+    passThrough.write(Buffer.from(' on the sameline', 'utf-8'));
+    passThrough.write(
+      Buffer.from('\nnow\nthere\nare\ndifferent\nlines\n', 'utf-8'),
+    );
+    passThrough.write(
+      Buffer.from(
+        '\n\nempty lines are skipped\nlast part should get flushed on end',
+        'utf-8',
+      ),
+    );
+    passThrough.end();
+
+    await endPromise;
+
+    expect(stub.callCount).to.equal(8);
+  });
+
+  it('should transform stream into lines for specified encoding', async () => {
+    const stub = sinon.stub();
+    const passThrough = new PassThrough();
+    const lt = new LineTransformer('ascii');
+    passThrough.pipe(lt);
+    lt.on('data', chunk => {
+      stub(chunk.toString());
+    });
+    const endPromise = new Promise(resolve => {
+      lt.on('end', resolve);
+    });
+
+    passThrough.write(Buffer.from('testing', 'ascii'));
+    passThrough.write(Buffer.from(' on the sameline', 'ascii'));
+    passThrough.write(
+      Buffer.from('\nnow\nthere\nare\ndifferent\nlines\n', 'ascii'),
+    );
+    passThrough.write(
+      Buffer.from(
+        '\n\nempty lines are skipped\nlast part should get flushed on end',
+        'ascii',
+      ),
+    );
+    passThrough.end();
+
+    await endPromise;
+
+    expect(stub.callCount).to.equal(8);
+  });
+
+  it('should use specific encoding if passed through', async () => {
+    const stub = sinon.stub();
+    const passThrough = new PassThrough();
+    const lt = new LineTransformer();
+    passThrough.pipe(lt);
+    lt.on('data', chunk => {
+      stub(chunk.toString());
+    });
+    const endPromise = new Promise(resolve => {
+      lt.on('end', resolve);
+    });
+
+    passThrough.write(Buffer.from('testing'), 'utf-8');
+    passThrough.write(' on the sameline');
+    passThrough.write(
+      Buffer.from('\nnow\nthere\nare\ndifferent\nlines\n', 'ascii'),
+      'ascii',
+    );
+    passThrough.write(
+      Buffer.from(
+        '\n\nempty lines are skipped\nlast part should get flushed on end',
+        'utf-8',
+      ),
+    );
+    passThrough.end();
+
+    await endPromise;
+
+    expect(stub.callCount).to.equal(8);
+  });
+
+  it('should error out when encoding is wrong', async () => {
+    const passThrough = new PassThrough();
+    const lt = new LineTransformer('buffer');
+    passThrough.pipe(lt);
+
+    const errorPromise = new Promise(resolve => {
+      lt.on('error', resolve);
+    });
+
+    passThrough.write('testing');
+
+    await errorPromise;
+
+    passThrough.end();
+  });
+
+  it('should end when incoming stream ends', async () => {
+    const stub = sinon.stub();
+    const passThrough = new PassThrough();
+    const lt = new LineTransformer();
+    passThrough.pipe(lt);
+    lt.on('data', chunk => {
+      stub(chunk.toString());
+    });
+    const endPromise = new Promise(resolve => {
+      lt.on('end', resolve);
+    });
+
+    passThrough.end();
+
+    await endPromise;
+
+    assert.isFalse(stub.called);
+  });
+});

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -1,0 +1,10 @@
+import { assert } from 'chai';
+import 'mocha';
+
+import topLevelWeb from '../src/web';
+
+it('top level web export should expose correct elements', () => {
+  assert.isDefined(topLevelWeb.ContentParser, 'Content Parser should be exposed');
+  assert.isDefined(topLevelWeb.ReportMode, 'Report Mode should be exposed');
+  assert.isDefined(topLevelWeb.StreamParser, 'Stream Parser should be exposed');
+});

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -4,7 +4,10 @@ import 'mocha';
 import topLevelWeb from '../src/web';
 
 it('top level web export should expose correct elements', () => {
-  assert.isDefined(topLevelWeb.ContentParser, 'Content Parser should be exposed');
+  assert.isDefined(
+    topLevelWeb.ContentParser,
+    'Content Parser should be exposed',
+  );
   assert.isDefined(topLevelWeb.ReportMode, 'Report Mode should be exposed');
   assert.isDefined(topLevelWeb.StreamParser, 'Stream Parser should be exposed');
 });

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "tsconfig.json",
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,21 +34,19 @@ const nodeConfig = {
   ...baseConfig,
   target: 'node',
   entry: {
-    'index': './src/index.ts',
+    'index.node': './src/node.ts',
   },
   node: {
     fs: true,
-  }
+    stream: true,
+  },
 };
 
 const webConfig = {
   ...baseConfig,
   target: 'web',
   entry: {
-    'index.umd': './src/index.ts',
-  },
-  node: {
-    fs: 'empty',
+    'index.web': './src/web.ts',
   },
 };
 


### PR DESCRIPTION
## Changes
- Create different variants for `StreamParser` that work in browser and in node environments
  - Named `BrowserStreamParser` and `NodeStreamParser` respectively
- Create abstract `StreamParser` class to contain shared implementation
  - Both `StreamParser` variants are subclasses on this abstract class instead of `Parser`
- Add Unit Tests for `StreamParser` and `NodeStreamParser`
  - `BrowserStreamParser` test are not added since we aren't testing in a browser environment yet
  - Once karma is setup, we can finish this last unit test
- Split Top Level Exports
  - Now there are two exports used based on the environment
  - This is a temporary change and will be updated to allow proper tree shaking
- Start linting test files
  - Should prevent bugs when writing tests
