### PR TITLE
Fix Transient Dependency Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "dist"
   ],
   "sideEffects": false,
+  "dependencies": {
+    "tslib": "^1.9.3"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
@@ -64,7 +67,6 @@
     "terser-webpack-plugin": "^1.2.3",
     "ts-loader": "^5.3.3",
     "ts-node": "^8.0.3",
-    "tslib": "^1.9.3",
     "tslint": "^5.13.1",
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.14.2",


### PR DESCRIPTION
## Changes
- Move `tslib` to be a direct dependency instead of devDependency
  - (Node only): Prevents a bug that prevents this package from being used as a dependency when `tslib` is not also added as a direct dependency. `tslib` will not be included as a transient dependency an does not explicitly need to be added to dependents of this package.